### PR TITLE
fix GetAssemblyFromSource for automate extension

### DIFF
--- a/mcs/class/System.Web/System.Web.UI/SimpleWebHandlerParser.cs
+++ b/mcs/class/System.Web/System.Web.UI/SimpleWebHandlerParser.cs
@@ -408,8 +408,7 @@ namespace System.Web.UI
 
 		Assembly GetAssemblyFromSource (string vpath, ILocation location)
 		{
-			vpath = UrlUtils.Combine (BaseVirtualDir, vpath);
-			string realPath = context.Request.MapPath (vpath);
+			string realPath =  UrlUtils.Combine(Path.GetDirectoryName(location.Filename),vpath);
 			if (!File.Exists (realPath))
 				throw new ParseException (location, "File " + vpath + " not found");
 


### PR DESCRIPTION
change how the source path is determined to be relative from the location of the file not the project base directory
